### PR TITLE
Ready for qa server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,75 @@ Puppet configuration and environment management for the Grasshopper event engine
  * If you make changes to the backend code you will need to restart the app server. This can be done by ssh'ing into the client machine by running `service grasshopper restart`.
  * Even if you'd install all the components on your host OS, you would not be able to run the server as some of the npm modules are compiled during the provisioning step.
 
-### Dev Environment (e.g. on EC2)
+### Local machine / Vagrant
+
+It's possible to get Grasshopper up and running on your local machine using [Vagrant](http://www.vagrantup.com) by following these steps:
+
+#### Preparation
+
+##### Install VirtualBox and Vagrant
+
+* Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* Install [Vagrant](http://downloads.vagrantup.com)
+
+##### Get the source code
+
+Clone [grasshopper](https://github.com/CUL-DigitalServices/grasshopper), [grasshopper-ui](https://github.com/CUL-DigitalServices/grasshopper-ui) and [grasshopper-puppet](https://github.com/CUL-DigitalServices/grasshopper-puppet) and make sure they are all in the same folder. You should have something like:
+
+```
++ grasshopper
+|-- + grasshopper
+|-- + grasshopper-ui
+|-- + grasshopper-puppet
+```
+
+You should **NOT** attempt to use these directories straight from your host OS as they will contain Linux specific compiled binaries and will not work on your host OS.
+Vice versa, do not try to share anything that you compiled on your host OS with Vagrant.
+
+##### Configure your hosts file
+
+The hosts file is a file that allows you to map fake domain names to certain IP addresses. By mapping them to
+the local loopback address we can fake multiple tenants running on one system.
+Edit your hosts file (`/etc/hosts` on UNIX, C:\Windows\System32\drivers\etc\hosts on Windows) and add the following entries.
+
+```
+127.0.0.1   admin.timetable.vagrant.com
+127.0.0.2   2014.timetable.vagrant.com
+127.0.0.2   2013.timetable.vagrant.com
+```
+
+##### Configure the amount of memory Vagrant/VirtualBox can use.
+
+By default the VM will be allotted 3072MB of RAM. If you do not have this much RAM available,
+you can change this in the VagrantFile found in grasshopper/grasshopper-puppet.
+
+#### Getting up and running
+
+cd into the `grasshopper-puppet` directory and run:
+
+```
+vagrant box add grasshopper https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box
+vagrant up
+```
+
+This command will pull down a VirtualBox image and deploy all the necessary components onto it.
+Depending on how fast your host machine and internet connection is, this can take quite a while. Initial set-ups of 30-45 minutes are not uncommon.
+
+(Note: this image already has puppet installed for convenience, though it will probably be an older version (3.4) than the puppet installed in the non-vagrant environments)
+
+Once that is done you should have a VM with a fully functioning environment.
+Open your browser and go to http://admin.vagrant.com and you should be presented with the Admin UI.
+
+#### Notes
+
+ * The app server logs can be found at /opt/grasshopper/server.log (or at grasshopper/grasshopper/server.log on your host machine).
+ * If you make changes to the backend code you will need to restart the app server. This can be done by ssh'ing into the client machine by running `vagrant ssh` and running `service grasshopper restart`.
+ * Even if you'd install all the components on your host OS, you would not be able to run the server as some of the npm modules are compiled during the provisioning step.
+ * If you've finished your development tasks or want to free up some resources for something else, you can run `vagrant halt` which will shutdown the VM.
+ * If you restart the VM using 'vagrant up', you may need to start Grasshopper server manually by running 'vagrant ssh' and 'sudo service grasshopper start'.
+
+
+### Dev and QA Environments (e.g. on EC2)
 
 #### Provisioning
 
@@ -80,72 +148,3 @@ but for instance, the `setup-via-api.sh` script won't know how to rename an app 
 - Could not retrieve fact='apt_security_updates'...
 ```
 
-
-### Local machine / Vagrant
-
-It's possible to get Grasshopper up and running on your local machine using [Vagrant](http://www.vagrantup.com) by following these steps:
-
-#### Preparation
-
-##### Install VirtualBox and Vagrant
-
-* Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-* Install [Vagrant](http://downloads.vagrantup.com)
-
-##### Get the source code
-
-Clone [grasshopper](https://github.com/CUL-DigitalServices/grasshopper), [grasshopper-ui](https://github.com/CUL-DigitalServices/grasshopper-ui) and [grasshopper-puppet](https://github.com/CUL-DigitalServices/grasshopper-puppet) and make sure they are all in the same folder. You should have something like:
-
-```
-+ grasshopper
-|-- + grasshopper
-|-- + grasshopper-ui
-|-- + grasshopper-puppet
-```
-
-You should **NOT** attempt to use these directories straight from your host OS as they will contain Linux specific compiled binaries and will not work on your host OS.
-Vice versa, do not try to share anything that you compiled on your host OS with Vagrant.
-
-##### Configure your hosts file
-
-The hosts file is a file that allows you to map fake domain names to certain IP addresses. By mapping them to
-the local loopback address we can fake multiple tenants running on one system.
-Edit your hosts file (`/etc/hosts` on UNIX, C:\Windows\System32\drivers\etc\hosts on Windows) and add the following entries.
-
-```
-127.0.0.1   admin.timetable.vagrant.com
-127.0.0.2   2014.timetable.vagrant.com
-127.0.0.2   2013.timetable.vagrant.com
-```
-
-##### Configure the amount of memory Vagrant/VirtualBox can use.
-
-By default the VM will be allotted 3072MB of RAM. If you do not have this much RAM available,
-you can change this in the VagrantFile found in grasshopper/grasshopper-puppet.
-
-#### Getting up and running
-
-cd into the `grasshopper-puppet` directory and run:
-
-```
-vagrant box add grasshopper https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box
-vagrant up
-```
-
-This command will pull down a VirtualBox image and deploy all the necessary components onto it.
-Depending on how fast your host machine and internet connection is, this can take quite a while. Initial set-ups of 30-45 minutes are not uncommon.
-
-(Note: this image already has puppet installed for convenience, though it will probably be an older version (3.4) than the puppet installed in the non-vagrant environments)
-
-Once that is done you should have a VM with a fully functioning environment.
-Open your browser and go to http://admin.vagrant.com and you should be presented with the Admin UI.
-
-#### Notes
-
- * The app server logs can be found at /opt/grasshopper/server.log (or at grasshopper/grasshopper/server.log on your host machine).
- * If you make changes to the backend code you will need to restart the app server. This can be done by ssh'ing into the client machine by running `vagrant ssh` and running `service grasshopper restart`.
- * Even if you'd install all the components on your host OS, you would not be able to run the server as some of the npm modules are compiled during the provisioning step.
- * If you've finished your development tasks or want to free up some resources for something else, you can run `vagrant halt` which will shutdown the VM.
- * If you restart the VM using 'vagrant up', you may need to start Grasshopper server manually by running 'vagrant ssh' and 'sudo service grasshopper start'.
-
-### QA

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Vice versa, do not try to share anything that you compiled on your host OS with 
 ##### Configure your hosts file
 
 The hosts file is a file that allows you to map fake domain names to certain IP addresses. By mapping them to
-the local loopback address we can fake multiple tenants running on one system.
+the Virtualbox VM IP address we can fake multiple tenants running on one system. (This IP address is specified in `Vagrantfile`).
 Edit your hosts file (`/etc/hosts` on UNIX, C:\Windows\System32\drivers\etc\hosts on Windows) and add the following entries.
 
 ```
-127.0.0.1   admin.timetable.vagrant.com
-127.0.0.2   2014.timetable.vagrant.com
-127.0.0.2   2013.timetable.vagrant.com
+192.168.56.123   admin.timetable.vagrant.com
+192.168.56.123   2014.timetable.vagrant.com
+192.168.56.123   2013.timetable.vagrant.com
 ```
 
 ##### Configure the amount of memory Vagrant/VirtualBox can use.

--- a/README.md
+++ b/README.md
@@ -10,58 +10,76 @@ Puppet configuration and environment management for the Grasshopper event engine
 
 ### Dev Environment (e.g. on EC2)
 
+#### Provisioning
+
+Provision an Ubuntu Trusty server, then:
 ```
-# Provision an Ubuntu Trusty server
-# Then:
 local$ ssh devserver.ontheinternet
 devserver$ sudo apt-get update
 devserver$ sudo apt-get -y install git
 # (If you're testing puppet changes not in main master, don't forget to modify this next line!)
 devserver$ sudo git clone git://github.com/CUL-DigitalServices/grasshopper-puppet /opt/grasshopper-puppet
 devserver$ cd /opt/grasshopper-puppet
+```
 
-# Edit common.json:
-# - to make tenant_hostname match your new server's hostname
-# - to change git config to match a tag if appropriate
-devserver$ sudo vim environments/dev/hiera/common.json
+Now edit `common.json`:
+* to make `tenant_hostname` match your new server's hostname
+* to change git config to match a tag if appropriate
 
-# Copy some timetable data to import onto the server
-local$ scp timetabledata.json devserver.ontheinternet:/tmp/timetabledata.json
+`devserver$ sudo vim environments/dev/hiera/common.json`
 
-# Back to the server to run puppet
-# This next step could take up to around 60mins if you have a slow server and lots of data to import!
-# Take note of the puppet command line displayed at the end, you may find it useful later
-devserver$ sudo ./provisioning/grasshopper/init.sh
+Copy some timetable data to import onto the server:
 
-# Set username and password to protect externally visible server with play data in
-# (This only applies in environments where ghservice::apache::enable_basic_auth is true)
-devserver$ sudo htpasswd -c /etc/apache2/dev_auth_file #username#
+`local$ scp timetabledata.json devserver.ontheinternet:/tmp/timetabledata.json`
 
-# In a web browser, try going to the hostname you entered into common.json above
-# It should show you the Student UI!
+Back to the server to run puppet. **Take note** of the puppet command line displayed at the end, you may find it useful later.
+This puppet step could take **at least 60 mins** if you have a slow server and lots of data to import!
 
-# You can monitor grasshopper's logs like this:
-devserver$ sudo tail -f /var/log/upstart/grasshopper.log
-# You can control the grasshopper server like this:
-devserver$ sudo service grasshopper [start|stop|restart]
+`devserver$ sudo ./provisioning/grasshopper/init.sh`
 
-## HANDY HINT, especially for EC2 users (and similar)
-## You may want to avoid changing your hostname - either get a static IP, or don't shutdown!
-## Otherwise reconfiguring the system with a new hostname might be fiddly
-## (Have not yet tested/audited how fiddly or whether puppet will fix it all;
-##  but for instance, the setup-via-api.sh script won't know how to rename an app etc)
+*Optional: only on environments like `dev` where `ghservice::apache::enable_basic_auth` is `true`:*
+* *Set username and password to protect externally visible server with play data in:*
+* *`devserver$ sudo htpasswd -c /etc/apache2/dev_auth_file #username#`*
 
-## NOTE: you may get some of the following warnings and errors, but these can safely be ignored:
+#### Client usage
+
+In a web browser, try going to the hostname you entered into `common.json` above, 
+it should show you the Student UI!
+
+If you wish to access the Global Admin (e.g. UI or Swagger Docs)
+you will need to edit the `/etc/hosts` file on the client that
+you wish to browse from. Add something like this to it:
+
+`nn.nnn.nn.n  admin.ec2-nn-nnn-nn-n.eu-west-1.compute.amazonaws.com`
+
+#### Grasshopper usage
+
+You can monitor grasshopper's logs like this:
+
+`devserver$ sudo tail -f /var/log/upstart/grasshopper.log`
+
+You can control the grasshopper server like this:
+
+`devserver$ sudo service grasshopper [start|stop|restart]`
+
+#### HANDY HINT, especially for EC2 users (and similar)
+
+You may want to **avoid changing your hostname** - either get a static IP, or don't shutdown!
+Otherwise reconfiguring the system with a new hostname might be fiddly.
+*(Have not yet tested/audited how fiddly or whether puppet will fix it all;
+but for instance, the `setup-via-api.sh` script won't know how to rename an app etc)*
+
+#### Known warnings and errors during provisioning
+
+**NOTE**: during the puppet step, you may get some of the following warnings and errors, but these can safely be ignored:
+*(Last two pertain to `/usr/lib/update-notifier/apt-check`)*
+
+```
 - Warning: Setting templatedir is deprecated ...
 - Could not retrieve fact='apt_updates'...
 - Could not retrieve fact='apt_security_updates'...
-(Last two pertain to /usr/lib/update-notifier/apt-check)
-
-## If you wish to access the Global Admin (e.g. UI or Swagger Docs)
-## you will need to edit the /etc/hosts file on the client that
-## you wish to browse from. Add something like this to it:
-nn.nnn.nn.n  admin.ec2-nn-nnn-nn-n.eu-west-1.compute.amazonaws.com
 ```
+
 
 ### Local machine / Vagrant
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ devserver$ sudo git clone git://github.com/CUL-DigitalServices/grasshopper-puppe
 devserver$ cd /opt/grasshopper-puppet
 ```
 
-Now edit `common.json`:
+Now edit the right `common.json` for your chosen environment (`dev`/`qa`):
 * to make `tenant_hostname` match your new server's hostname
 * to change git config to match a tag if appropriate
 
-`devserver$ sudo vim environments/dev/hiera/common.json`
+`devserver$ sudo vim environments/[dev|qa]/hiera/common.json`
 
 Copy some timetable data to import onto the server:
 
@@ -103,7 +103,7 @@ Copy some timetable data to import onto the server:
 Back to the server to run puppet. **Take note** of the puppet command line displayed at the end, you may find it useful later.
 This puppet step could take **at least 60 mins** if you have a slow server and lots of data to import!
 
-`devserver$ sudo ./provisioning/grasshopper/init.sh`
+`devserver$ sudo ./provisioning/grasshopper/init.sh [dev|qa]`
 
 *Optional: only on environments like `dev` where `ghservice::apache::enable_basic_auth` is `true`:*
 * *Set username and password to protect externally visible server with play data in:*

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ devserver$ cd /opt/grasshopper-puppet
 
 Now edit the right `common.json` for your chosen environment (`dev`/`qa`):
 * to make `tenant_hostname` match your new server's hostname
-* to change git config to match a tag if appropriate
+* review the two git `revision`s under `app_install_config`: if appropriate, edit each to a commit SHA, tag or branch name of your choice
 
 `devserver$ sudo vim environments/[dev|qa]/hiera/common.json`
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,16 @@ Puppet configuration and environment management for the Grasshopper event engine
 ## Environments
 
  * The app server logs can be found at /opt/grasshopper/server.log
- * If you make changes to the backend code you will need to restart the app server. This can be done by ssh'ing into the client machine by running `service grasshopper restart`.
- * Even if you'd install all the components on your host OS, you would not be able to run the server as some of the npm modules are compiled during the provisioning step.
+ * If you make changes to the backend code you will need to restart the app server.
+   This can be done by ssh'ing into the client machine by running `service grasshopper restart`.
+ * Even if you'd install all the components on your host OS, you would not be
+   able to run the server as some of the npm modules are compiled during the
+   provisioning step.
 
 ### Local machine / Vagrant
 
-It's possible to get Grasshopper up and running on your local machine using [Vagrant](http://www.vagrantup.com) by following these steps:
+It's possible to get Grasshopper up and running on your local machine using
+[Vagrant](http://www.vagrantup.com) by following these steps:
 
 #### Preparation
 
@@ -21,7 +25,10 @@ It's possible to get Grasshopper up and running on your local machine using [Vag
 
 ##### Get the source code
 
-Clone [grasshopper](https://github.com/CUL-DigitalServices/grasshopper), [grasshopper-ui](https://github.com/CUL-DigitalServices/grasshopper-ui) and [grasshopper-puppet](https://github.com/CUL-DigitalServices/grasshopper-puppet) and make sure they are all in the same folder. You should have something like:
+Clone [grasshopper](https://github.com/CUL-DigitalServices/grasshopper),
+[grasshopper-ui](https://github.com/CUL-DigitalServices/grasshopper-ui) and
+[grasshopper-puppet](https://github.com/CUL-DigitalServices/grasshopper-puppet)
+and make sure they are all in the same folder. You should have something like:
 
 ```
 + grasshopper
@@ -30,14 +37,19 @@ Clone [grasshopper](https://github.com/CUL-DigitalServices/grasshopper), [grassh
 |-- + grasshopper-puppet
 ```
 
-You should **NOT** attempt to use these directories straight from your host OS as they will contain Linux specific compiled binaries and will not work on your host OS.
-Vice versa, do not try to share anything that you compiled on your host OS with Vagrant.
+You should **NOT** attempt to use these directories straight from your host OS
+as they will contain Linux specific compiled binaries and will not work on your
+host OS.
+Vice versa, do not try to share anything that you compiled on your host OS with
+Vagrant.
 
 ##### Configure your hosts file
 
-The hosts file is a file that allows you to map fake domain names to certain IP addresses. By mapping them to
-the Virtualbox VM IP address we can fake multiple tenants running on one system. (This IP address is specified in `Vagrantfile`).
-Edit your hosts file (`/etc/hosts` on UNIX, C:\Windows\System32\drivers\etc\hosts on Windows) and add the following entries.
+The hosts file is a file that allows you to map fake domain names to certain IP
+addresses. By mapping them to the Virtualbox VM IP address we can fake multiple
+tenants running on one system. (This IP address is specified in `Vagrantfile`).
+Edit your hosts file (`/etc/hosts` on UNIX,
+C:\Windows\System32\drivers\etc\hosts on Windows) and add the following entries.
 
 ```
 192.168.56.123   admin.timetable.vagrant.com
@@ -47,8 +59,9 @@ Edit your hosts file (`/etc/hosts` on UNIX, C:\Windows\System32\drivers\etc\host
 
 ##### Configure the amount of memory Vagrant/VirtualBox can use.
 
-By default the VM will be allotted 3072MB of RAM. If you do not have this much RAM available,
-you can change this in the VagrantFile found in grasshopper/grasshopper-puppet.
+By default the VM will be allotted 3072MB of RAM. If you do not have this much
+RAM available, you can change this in the VagrantFile found in
+grasshopper/grasshopper-puppet.
 
 #### Getting up and running
 
@@ -59,21 +72,33 @@ vagrant box add grasshopper https://oss-binaries.phusionpassenger.com/vagrant/bo
 vagrant up
 ```
 
-This command will pull down a VirtualBox image and deploy all the necessary components onto it.
-Depending on how fast your host machine and internet connection is, this can take quite a while. Initial set-ups of 30-45 minutes are not uncommon.
+This command will pull down a VirtualBox image and deploy all the necessary
+components onto it. Depending on how fast your host machine and internet
+connection is, this can take quite a while. Initial set-ups of 30-45 minutes
+are not uncommon.
 
-(Note: this image already has puppet installed for convenience, though it will probably be an older version (3.4) than the puppet installed in the non-vagrant environments)
+(Note: this image already has puppet installed for convenience, though it will
+probably be an older version (3.4) than the puppet installed in the non-vagrant
+environments)
 
 Once that is done you should have a VM with a fully functioning environment.
-Open your browser and go to http://admin.vagrant.com and you should be presented with the Admin UI.
+Open your browser and go to http://admin.vagrant.com and you should be presented
+with the Admin UI.
 
 #### Notes
 
- * The app server logs can be found at /opt/grasshopper/server.log (or at grasshopper/grasshopper/server.log on your host machine).
- * If you make changes to the backend code you will need to restart the app server. This can be done by ssh'ing into the client machine by running `vagrant ssh` and running `service grasshopper restart`.
- * Even if you'd install all the components on your host OS, you would not be able to run the server as some of the npm modules are compiled during the provisioning step.
- * If you've finished your development tasks or want to free up some resources for something else, you can run `vagrant halt` which will shutdown the VM.
- * If you restart the VM using 'vagrant up', you may need to start Grasshopper server manually by running 'vagrant ssh' and 'sudo service grasshopper start'.
+ * The app server logs can be found at /opt/grasshopper/server.log (or at
+   grasshopper/grasshopper/server.log on your host machine).
+ * If you make changes to the backend code you will need to restart the app server.
+   This can be done by ssh'ing into the client machine by running `vagrant ssh`
+   and running `service grasshopper restart`.
+ * Even if you'd install all the components on your host OS, you would not be
+   able to run the server as some of the npm modules are compiled during the
+   provisioning step.
+ * If you've finished your development tasks or want to free up some resources
+   for something else, you can run `vagrant halt` which will shutdown the VM.
+ * If you restart the VM using 'vagrant up', you may need to start Grasshopper
+   server manually by running 'vagrant ssh' and 'sudo service grasshopper start'.
 
 
 ### Dev and QA Environments (e.g. on EC2)
@@ -92,7 +117,8 @@ devserver$ cd /opt/grasshopper-puppet
 
 Now edit the right `common.json` for your chosen environment (`dev`/`qa`):
 * to make `tenant_hostname` match your new server's hostname
-* review the two git `revision`s under `app_install_config`: if appropriate, edit each to a commit SHA, tag or branch name of your choice
+* review the two git `revision`s under `app_install_config`: if appropriate,
+  edit each to a commit SHA, tag or branch name of your choice
 
 `devserver$ sudo vim environments/[dev|qa]/hiera/common.json`
 
@@ -100,8 +126,9 @@ Copy some timetable data to import onto the server:
 
 `local$ scp timetabledata.json devserver.ontheinternet:/tmp/timetabledata.json`
 
-Back to the server to run puppet. **Take note** of the puppet command line displayed at the end, you may find it useful later.
-This puppet step could take **at least 60 mins** if you have a slow server and lots of data to import!
+Back to the server to run puppet. **Take note** of the puppet command line
+displayed at the end, you may find it useful later. This puppet step could take
+**at least 60 mins** if you have a slow server and lots of data to import!
 
 `devserver$ sudo ./provisioning/grasshopper/init.sh [dev|qa]`
 
@@ -114,9 +141,9 @@ This puppet step could take **at least 60 mins** if you have a slow server and l
 In a web browser, try going to the hostname you entered into `common.json` above, 
 it should show you the Student UI!
 
-If you wish to access the Global Admin (e.g. UI or Swagger Docs)
-you will need to edit the `/etc/hosts` file on the client that
-you wish to browse from. Add something like this to it:
+If you wish to access the Global Admin (e.g. UI or Swagger Docs) you will need
+to edit the `/etc/hosts` file on the client that you wish to browse from. Add
+something like this to it:
 
 `nn.nnn.nn.n  admin.ec2-nn-nnn-nn-n.eu-west-1.compute.amazonaws.com`
 
@@ -132,15 +159,17 @@ You can control the grasshopper server like this:
 
 #### HANDY HINT, especially for EC2 users (and similar)
 
-You may want to **avoid changing your hostname** - either get a static IP, or don't shutdown!
-Otherwise reconfiguring the system with a new hostname might be fiddly.
+You may want to **avoid changing your hostname** - either get a static IP, or
+don't shutdown! Otherwise reconfiguring the system with a new hostname might be
+fiddly.
 *(Have not yet tested/audited how fiddly or whether puppet will fix it all;
 but for instance, the `setup-via-api.sh` script won't know how to rename an app etc)*
 
 #### Known warnings and errors during provisioning
 
-**NOTE**: during the puppet step, you may get some of the following warnings and errors, but these can safely be ignored:
-*(Last two pertain to `/usr/lib/update-notifier/apt-check`)*
+**NOTE**: during the puppet step, you may get some of the following warnings and
+errors, but these can safely be ignored: *(Last two pertain to
+`/usr/lib/update-notifier/apt-check`)*
 
 ```
 - Warning: Setting templatedir is deprecated ...

--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ with the Admin UI.
 
 #### Provisioning
 
-Provision an Ubuntu Trusty server, then:
+Provision an Ubuntu Trusty server.
+
+If you need to assign it a static IP address, do this **NOW** before going
+any further. (More information about this further below).
+
+Next:
 ```
 local$ ssh devserver.ontheinternet
 devserver$ sudo apt-get update

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,9 @@ Vagrant.configure("2") do |config|
   # Use the "grasshopper" box to host
   config.vm.box = "grasshopper"
 
-  # Forward http traffic
+  # Rather than forwarding ports from the Virtualbox to the host OS localhost,
+  # we create an environment that is more similar to EC2, where the Virtualbox
+  # VM gets its own IP address (albeit only accessible from your host box).
   config.vm.network "private_network", ip: "192.168.56.123"
 
   # Share the back-end and front-end code with Vagrant.

--- a/environments/local/modules/localconfig/manifests/nodes.pp
+++ b/environments/local/modules/localconfig/manifests/nodes.pp
@@ -1,4 +1,4 @@
-node 'dev0' {
+node 'local0' {
     $nodetype = 'dev'
     $nodesuffix = 0
     hiera_include(classes)

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -1,11 +1,31 @@
 {
-    "classes": [],
+    "classes": [
+        "::localconfig::ordering",
+        "::localconfig::hostnames",
+        "::ghservice::deps::common",
+        "::ghservice::apache",
+        "::ghservice::grasshopper",
+        "::ghservice::postgresql",
+        "::ghservice::ui"
+    ],
+
+    /* Domains and hostnames */
+    "admin_hostname": "admin.%{hiera('tenant_hostname')}",
+    "tenant_hostname": "ec2-nn-nn-nn-nn.eu-west-1.compute.amazonaws.com",
+
+    // In future when we have DNS for real hostnames,
+    // one would probably want to structure domains like so:
+    // web_domain:      timetable.cam.ac.uk
+    // tenants:    2014.timetable.cam.ac.uk
+    //             2015.timetable.cam.ac.uk
+    // admin:     admin.timetable.cam.ac.uk
+    "web_domain": "not_used",
 
     /* Puppet node settings */
     "nodesuffix": "%{nodesuffix}",
     "nodetype": "%{nodetype}",
 
-    /* Generel Grasshopper application settings */
+    /* General Grasshopper application settings */
     "app_os_user": "root",
     "app_os_group": "root",
 
@@ -28,16 +48,21 @@
     "ui_root_dir": "/opt/grasshopper-ui",
     "ui_install_method": "git",
     "ui_install_config": {
-        "source": "https://github.com/CUL-DigitalServices/avocet-ui.git",
+        "source": "https://github.com/CUL-DigitalServices/grasshopper-ui.git",
         "revision": "master"
     },
 
     /* Node.JS version */
-    "ghservice::deps::package::nodejs::nodejs_version": "0.10.35-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.36-1nodesource1~trusty1",
+
+    /* PostgreSQL settings */
+    "ghservice::postgresql::version": "",
+    "ghservice::postgresql::db": "grasshopper",
+    "ghservice::postgresql::user": "grasshopper",
+    "ghservice::postgresql::pass": "grasshopper",
 
     /* Apache directives */
     "ghservice::apache::version": "",
+    "ghservice::apache::enable_basic_auth": "true"
 
-    /* PostGres directives */
-    "ghservice::postgresql::version": ""
 }

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -43,7 +43,7 @@
     "app_install_method": "git",
     "app_install_config": {
         "source": "https://github.com/CUL-DigitalServices/grasshopper.git",
-        "revision": "aa6778632f49c148b6589cf949e6f6b29bec3d80"
+        "revision": "ccf099550f74dded246c2cee9cb91d1cc30e78d8"
     },
 
     /* Grasshopper UI repository */
@@ -51,7 +51,7 @@
     "ui_install_method": "git",
     "ui_install_config": {
         "source": "https://github.com/CUL-DigitalServices/grasshopper-ui.git",
-        "revision": "6df786cf5bd4d95c9e323586208dce3bfba9f55e"
+        "revision": "0fc9a17607d20a6b662ea3b25b7a7972f74a6538"
     },
 
     /* Node.JS version */

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -36,6 +36,8 @@
         "127.0.0.2"
     ],
 
+    "grasshopper::setup::tenant_appdisplayname_escaped": "My+Timetable+-+Beta",
+
     /* Grasshopper repository */
     "app_ui_path": "/opt/grasshopper-ui",
     "app_install_method": "git",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -41,7 +41,7 @@
     "app_install_method": "git",
     "app_install_config": {
         "source": "https://github.com/CUL-DigitalServices/grasshopper.git",
-        "revision": "master"
+        "revision": "aa6778632f49c148b6589cf949e6f6b29bec3d80"
     },
 
     /* Grasshopper UI repository */
@@ -49,7 +49,7 @@
     "ui_install_method": "git",
     "ui_install_config": {
         "source": "https://github.com/CUL-DigitalServices/grasshopper-ui.git",
-        "revision": "master"
+        "revision": "6df786cf5bd4d95c9e323586208dce3bfba9f55e"
     },
 
     /* Node.JS version */
@@ -63,6 +63,6 @@
 
     /* Apache directives */
     "ghservice::apache::version": "",
-    "ghservice::apache::enable_basic_auth": "true"
+    "ghservice::apache::enable_basic_auth": "false"
 
 }

--- a/environments/qa/hiera/qa.json
+++ b/environments/qa/hiera/qa.json
@@ -1,9 +1,0 @@
-{
-    "classes": [
-        "::localconfig::ordering",
-        "::ghservice::apache",
-        "::ghservice::postgresql",
-        "::ghservice::grasshopper",
-        "::ghservice::ui"
-    ]
-}

--- a/environments/qa/hiera/qa0.json
+++ b/environments/qa/hiera/qa0.json
@@ -1,3 +1,0 @@
-{
-    "web_domain": "qa0.timetable.grasshopper.com"
-}

--- a/environments/qa/modules/localconfig/manifests/hostnames.pp
+++ b/environments/qa/modules/localconfig/manifests/hostnames.pp
@@ -1,0 +1,12 @@
+class localconfig::hostnames {
+
+    $admin_hostname = hiera('admin_hostname')
+    $tenant_hostname = hiera('tenant_hostname')
+
+    # These are defined to allow puppet and setup scripts to access
+    # the node server ports on 2000 and 2001 locally, whilst still
+    # using external hostnames, and not opening those ports to the world
+    # Additionally, on EC2 admin_hostname won't be in DNS either
+    host { $admin_hostname: ip => '127.0.0.1' }
+    host { $tenant_hostname: ip => '127.0.0.1' }
+}

--- a/environments/qa/modules/localconfig/manifests/nodes.pp
+++ b/environments/qa/modules/localconfig/manifests/nodes.pp
@@ -1,10 +1,5 @@
-node 'qa0' {
-    $nodetype = 'qa'
+node 'dev0' {
+    $nodetype = 'dev'
     $nodesuffix = 0
-    hiera_include(classes)
-}
-
-node 'puppet' {
-    $nodetype = 'puppet'
     hiera_include(classes)
 }

--- a/environments/qa/modules/localconfig/manifests/nodes.pp
+++ b/environments/qa/modules/localconfig/manifests/nodes.pp
@@ -1,4 +1,4 @@
-node 'dev0' {
+node 'qa0' {
     $nodetype = 'dev'
     $nodesuffix = 0
     hiera_include(classes)

--- a/modules/ghservice/manifests/apache.pp
+++ b/modules/ghservice/manifests/apache.pp
@@ -35,7 +35,7 @@ class ghservice::apache (
     $path_robotstxt         = '/var/www/robots.txt'
 
     file { $path_robotstxt:
-       source => 'puppet:///modules/ghservice/robots.txt.disallowall'
+        source => 'puppet:///modules/ghservice/robots.txt.disallowall'
     }
 
     # VirtualHosts are loaded in alphabetical order;

--- a/modules/ghservice/manifests/deps/nodejs.pp
+++ b/modules/ghservice/manifests/deps/nodejs.pp
@@ -8,11 +8,10 @@ class ghservice::deps::nodejs (
         manage_repo => true
     }
 
-    # This next section is necessary to ensure the above class
-    # is actually contained within the surrounding class
-    # because by default puppet will let that nodejs declaration float freely in
-    # the dependency graph, resulting in commands like npm install trying
-    # to run too early.
+    # This next section is necessary to ensure the above class is actually
+    # contained within the surrounding class because by default puppet will let
+    # that nodejs declaration float freely in the dependency graph, resulting in
+    # commands like npm install trying to run too early.
     # https://docs.puppetlabs.com/puppet/latest/reference/lang_containment.html#anchor-pattern-containment-for-compatibility-with-puppet--340
 
     anchor { 'nodejs_begin': } ->

--- a/modules/ghservice/manifests/postgresql.pp
+++ b/modules/ghservice/manifests/postgresql.pp
@@ -5,7 +5,6 @@ class ghservice::postgresql (
     ) {
 
     class { 'postgresql::server': }
-
     class { 'postgresql::server::contrib': }
 
     postgresql::server::db { "$db":

--- a/modules/ghservice/templates/apache/app_admin.conf.erb
+++ b/modules/ghservice/templates/apache/app_admin.conf.erb
@@ -82,12 +82,12 @@
     Alias /robots.txt <%= @path_robotstxt %>
 
 <% if @enable_basic_auth == "true" -%>
-    <Directory />
+    <Location />
         AuthType basic
         AuthName "Grasshopper Dev Server (Global Admin)"
         AuthUserFile /etc/apache2/dev_auth_file
         Require valid-user
-    </Directory>
+    </Location>
 <% end -%>
 
     ##

--- a/modules/ghservice/templates/apache/app_timetable.conf.erb
+++ b/modules/ghservice/templates/apache/app_timetable.conf.erb
@@ -74,12 +74,12 @@
     Alias /robots.txt <%= @path_robotstxt %>
 
 <% if @enable_basic_auth == "true" -%>
-    <Directory />
+    <Location />
         AuthType basic
         AuthName "Grasshopper Dev Server (Tenant)"
         AuthUserFile /etc/apache2/dev_auth_file
         Require valid-user
-    </Directory>
+    </Location>
 <% end -%>
 
     ##

--- a/modules/grasshopper/files/setup-via-api.sh
+++ b/modules/grasshopper/files/setup-via-api.sh
@@ -2,9 +2,10 @@
 
 ADMINHOSTNAME=$1
 TENANTHOSTNAME=$2
+TENANTAPPDISPLAYNAME=$3
 
-if [[ X"" = X"$ADMINHOSTNAME" || X"" = X"$TENANTHOSTNAME" ]]; then
-echo "Usage: $0 admin.domain.com tenant.domain.com"
+if [[ X"" = X"$ADMINHOSTNAME" || X"" = X"$TENANTHOSTNAME" || X"" = X"$TENANTAPPDISPLAYNAME" ]]; then
+echo "Usage: $0 admin.domain.com tenant.domain.com Display+Name+Escaped"
   exit 0;
 fi
 
@@ -21,7 +22,7 @@ curl -b /tmp/curlcookiejar -c /tmp/curlcookiejar -w '\nHTTP STATUS: %{http_code}
 ### assume returns "id":1
 
 # CREATE APP (needs tenantId from above, change host param to match)
-curl -b /tmp/curlcookiejar -c /tmp/curlcookiejar -w '\nHTTP STATUS: %{http_code}\nTIME: %{time_total}\n' -e / ${ADMINHOSTNAME}:2000/api/apps -X POST -d 'displayName=2014.dev.grasshopper&tenantId=1&host='$TENANTHOSTNAME'&type=timetable' || exit 1;
+curl -b /tmp/curlcookiejar -c /tmp/curlcookiejar -w '\nHTTP STATUS: %{http_code}\nTIME: %{time_total}\n' -e / ${ADMINHOSTNAME}:2000/api/apps -X POST -d 'displayName='$TENANTAPPDISPLAYNAME'&tenantId=1&host='$TENANTHOSTNAME'&type=timetable' || exit 1;
 ### assume returns "id":1
 
 # CREATE APP USERS (needs appId from above)

--- a/modules/grasshopper/manifests/install/git.pp
+++ b/modules/grasshopper/manifests/install/git.pp
@@ -12,6 +12,7 @@ class grasshopper::install::git ($install_config, $app_root_dir = '/opt/grasshop
         provider  => git,
         source    => $_install_config['source'],
         revision  => $_install_config['revision'],
+        notify    => Service['grasshopper'],
     } ->
 
     # We need to chmod the directory before we can do an npm install

--- a/modules/grasshopper/manifests/setup.pp
+++ b/modules/grasshopper/manifests/setup.pp
@@ -27,14 +27,33 @@ class grasshopper::setup (
 
   }
 
+
   exec { 'temporarily-stop-grasshopper-for-import':
       # if file for import exists and server is responding, stop the server
       onlyif  => "test -f /tmp/timetabledata.json && curl --fail ${admin_test_url}",
+
+      # "creates => foo" is confusing puppet-speak for:
+      # "command will create file foo, so don't execute if foo already exists"
+      #
+      # In actual fact, the next exec below "creates" the file.
+      # We replicate the conditional on this exec so that we don't stop
+      # grasshopper unless we're actually planning to import anything.
       creates => "/opt/timetabledata.json.imported",
+
       command => 'stop grasshopper && sleep 5',
   } ->
+
+  # If     /tmp/timetabledata.json exists
+  #    and /opt/timetabledata.json.imported does not exist:
+  #
+  # Then import /tmp/timetabledata.json
+  #
+  # If successfully imported
+  # Then move the file to /opt/timetabledata.json.imported
+  #
   exec { 'import-timetable-data':
       onlyif  => "test -f /tmp/timetabledata.json",
+      # The "mv" part of the command results in this file being "created":
       creates => "/opt/timetabledata.json.imported",
       # NOTE app-id currently hardcoded 1 to match setup-via-api.sh
       command => "node ${app_root_dir}/etc/scripts/data/timetable-import.js --file /tmp/timetabledata.json --app 1 && mv -i /tmp/timetabledata.json /opt/timetabledata.json.imported",

--- a/modules/grasshopper/manifests/setup.pp
+++ b/modules/grasshopper/manifests/setup.pp
@@ -3,6 +3,7 @@ class grasshopper::setup (
     $app_root_dir,
     $admin_hostname,
     $tenant_hostname,
+    $tenant_appdisplayname_escaped = "My+Timetable+-+Experimental+Dev+Server",
     $admin_test_url,
     $tenant_test_url,
     $tenant_login_url
@@ -21,7 +22,7 @@ class grasshopper::setup (
       exec { 'initial-setup-via-REST-API':
           # Hardcoded user/pass to match setup-via-api.sh
           unless  => "curl --fail ${tenant_login_url} -e / -X POST -d 'username=admin@test.local&password=admin'",
-          command => "/tmp/setup-via-api.sh ${admin_hostname} ${tenant_hostname}"
+          command => "/tmp/setup-via-api.sh ${admin_hostname} ${tenant_hostname} ${tenant_appdisplayname_escaped}"
       } -> Exec['temporarily-stop-grasshopper-for-import']
 
   }

--- a/modules/grasshopper/manifests/setup.pp
+++ b/modules/grasshopper/manifests/setup.pp
@@ -28,8 +28,8 @@ class grasshopper::setup (
   }
 
 
+  # if file for import exists and server is responding, stop the server
   exec { 'temporarily-stop-grasshopper-for-import':
-      # if file for import exists and server is responding, stop the server
       onlyif  => "test -f /tmp/timetabledata.json && curl --fail ${admin_test_url}",
 
       # "creates => foo" is confusing puppet-speak for:

--- a/modules/ui/manifests/install/git.pp
+++ b/modules/ui/manifests/install/git.pp
@@ -11,5 +11,6 @@ class ui::install::git ($install_config, $ui_root_dir = '/opt/grasshopper-ui') {
         provider  => git,
         source    => $_install_config['source'],
         revision  => $_install_config['revision'],
+        notify    => Service['grasshopper'],
     }
 }

--- a/provisioning/common.sh
+++ b/provisioning/common.sh
@@ -18,7 +18,7 @@ fi
 # Enable multiverse repositories
 echo "Enable multiverse repositories"
 sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list
-#apt-get update
+# No need to "apt-get update" as puppetlabs-apt will do it for us
 
 # Make sure all the submodules have been pulled down
 cd ${PUPPET_REPO_DIR}
@@ -28,7 +28,6 @@ sh bin/pull.sh
 cp ${PUPPET_HIERA} /etc/puppet/hiera.yaml
 
 # Run puppet
-
 PUPPET_EXTRA_OPTS="--verbose"
 PUPPET_CMD="puppet apply ${PUPPET_EXTRA_OPTS} --modulepath environments/${PUPPET_ENV}/modules:modules:/etc/puppet/modules --certname dev0 --environment ${PUPPET_ENV} --hiera_config /etc/puppet/hiera.yaml site.pp"
 

--- a/provisioning/common.sh
+++ b/provisioning/common.sh
@@ -5,6 +5,9 @@ PUPPET_HIERA=$2
 PUPPET_ENV=$3
 MANUALRUN_PREFIX=$4
 
+# For now default to env=dev means node=dev0 etc
+PUPPET_NODENAME="${PUPPET_ENV}0"
+
 cd ${PUPPET_REPO_DIR}
 
 # Install cURL
@@ -29,7 +32,7 @@ cp ${PUPPET_HIERA} /etc/puppet/hiera.yaml
 
 # Run puppet
 PUPPET_EXTRA_OPTS="--verbose"
-PUPPET_CMD="puppet apply ${PUPPET_EXTRA_OPTS} --modulepath environments/${PUPPET_ENV}/modules:modules:/etc/puppet/modules --certname dev0 --environment ${PUPPET_ENV} --hiera_config /etc/puppet/hiera.yaml site.pp"
+PUPPET_CMD="puppet apply ${PUPPET_EXTRA_OPTS} --modulepath environments/${PUPPET_ENV}/modules:modules:/etc/puppet/modules --certname ${PUPPET_NODENAME} --environment ${PUPPET_ENV} --hiera_config /etc/puppet/hiera.yaml site.pp"
 
 echo "Applying puppet catalog. This might take a while (~30+ mins is not unreasonable)"
 ${PUPPET_CMD}

--- a/provisioning/grasshopper/init.sh
+++ b/provisioning/grasshopper/init.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+PUPPET_ENV=$1
+
+if [[ X"" = X"$PUPPET_ENV" ]]; then
+  echo "Usage: $0 environmentname"
+  echo "  See environments directory for a list of valid environment names."
+  exit 0;
+fi
+
 # Include the Puppet APT repository
 echo "Fetching Puppet"
 cd /tmp
@@ -18,7 +26,6 @@ fi
 
 PUPPET_REPO_DIR=/opt/grasshopper-puppet
 PROVIS_DIR=${PUPPET_REPO_DIR}/provisioning
-PUPPET_ENV=dev
 
 ${PROVIS_DIR}/common.sh ${PUPPET_REPO_DIR} ${PROVIS_DIR}/grasshopper/hiera.yaml ${PUPPET_ENV} "Run this command:"
 


### PR DESCRIPTION
Notes:
- Please don't deploy the "real" QA server yet until I've had a chance to chat to you both, but feel free to provision practice versions of it
- **NOTE**: provisioning/grasshopper/init.sh now takes an argument, e.g. "qa"
- Fixed a bug with auth protection, it used to let /api be publicly accessible, you might want to update any dev servers you have provisioned
- Fixed applicable stuff in PR #3
  - Replies to specific points:
    - Re: AMI preference - I haven't decided anything definitively, I will chat you both about this later
    - Re: Extras in Apache conf - the only two extras are robots.txt and basic-auth protection - not sure if you really want these in grasshopper-ui (and grasshopper) ?
- QA environment is almost the same as dev except
  - Publicly accessible (no basic auth)
  - Example Git Revisions in `common.json` are now commit SHAs instead of "master", but you will want to **change them** to something deliberately chosen for QA
  - Default App DisplayName for QA is "My Timetable - Beta" (but you can change this in `common.json` where all the other settings are like hostname and git revisions)
