### PR TITLE
Add swagger API docs to tenant as requested by @oszkarnagy

### DIFF
--- a/modules/ghservice/templates/apache/app_timetable.conf.erb
+++ b/modules/ghservice/templates/apache/app_timetable.conf.erb
@@ -32,6 +32,9 @@
     # Shared files
     Alias /shared <%= @path_shared %>
 
+    # API docs
+    Alias /docs <%= @path_docs %>
+
     # App files
     Alias /apps <%= @path_apps %>
 


### PR DESCRIPTION
Assuming there isn't any special reason why swagger was only installed on the Global Admin and not in the Tenant Apache config, please merge this if you're happy with it. I will then update the QA server as requested by @oszkarnagy. I will also create a new PR for grasshopper-ui so that you get the corresponding change too.
