### PR TITLE
Bump node version used on QA/Dev

### DIFF
--- a/environments/dev/hiera/common.json
+++ b/environments/dev/hiera/common.json
@@ -53,7 +53,7 @@
     },
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.36-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",

--- a/environments/local/hiera/common.json
+++ b/environments/local/hiera/common.json
@@ -47,7 +47,7 @@
     "ui_install_config": {},
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.36-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -55,7 +55,7 @@
     },
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.36-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",


### PR DESCRIPTION
This is necessary because the `0.10.26-1nodesource1~trusty1` package is no longer available.
