### PR TITLE
Bump node version up to 0.10.38-1chl1~trusty1 for all envs as 0.10.37 no...

### DIFF
--- a/environments/dev/hiera/common.json
+++ b/environments/dev/hiera/common.json
@@ -53,7 +53,7 @@
     },
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.38-1chl1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",

--- a/environments/local/hiera/common.json
+++ b/environments/local/hiera/common.json
@@ -47,7 +47,7 @@
     "ui_install_config": {},
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.38-1chl1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",

--- a/environments/qa/hiera/common.json
+++ b/environments/qa/hiera/common.json
@@ -55,7 +55,7 @@
     },
 
     /* Node.JS version */
-    "ghservice::deps::nodejs::nodejs_version": "0.10.37-1nodesource1~trusty1",
+    "ghservice::deps::nodejs::nodejs_version": "0.10.38-1chl1~trusty1",
 
     /* PostgreSQL settings */
     "ghservice::postgresql::version": "",


### PR DESCRIPTION
... longer available

The latest version from https://deb.nodesource.com/node/dists/trusty/main/binary-amd64/ appears to also have been renamed to have "chl" instead of "nodesource" in its name - probably after Chris Lea.

When we have more time then we can perhaps think about automating this - but bearing in mind that a) we want to make sure we get the deb.nodesource.com version not Ubuntu default, and b) that the latest from deb.nodesource.com is actually version 0.12.\* not 0.10.*. For now let's just keep it working...
